### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+evilwm (1.1.1-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:15:15 +0100
+
 evilwm (1.1.1-1) unstable; urgency=medium
 
   * New upstream release. (Closes: #725494)

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), x11proto-core-dev, libx11-dev,
   x11proto-xext-dev, libxrandr-dev, doc-base
 Standards-Version: 3.9.6
 Homepage: http://www.6809.org.uk/evilwm/
-Vcs-Git: git://github.com/mati75/evilwm.git
+Vcs-Git: https://github.com/mati75/evilwm.git
 Vcs-Browser: https://github.com/mati75/evilwm.git
 
 Package: evilwm


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
