### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ evilwm (1.4.0-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Update renamed lintian tag names in lintian overrides.
+  * Set field Upstream-Contact in debian/copyright.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 30 Oct 2022 11:29:40 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,13 @@
+evilwm (1.4.0-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 30 Oct 2022 11:29:40 -0000
+
 evilwm (1.4.0-1) unstable; urgency=medium
 
   * New upstream release:
-    + Removed patches included upstream and refreshed rest. 
+    + Removed patches included upstream and refreshed rest.
   * Bump standards version to 4.6.1
 
  -- Mateusz Łukasik <mati75@linuxmint.pl>  Fri, 28 Oct 2022 17:35:13 +0200

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 evilwm (1.4.0-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Update renamed lintian tag names in lintian overrides.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 30 Oct 2022 11:29:40 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,8 @@ evilwm (1.4.0-2) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Update renamed lintian tag names in lintian overrides.
   * Set field Upstream-Contact in debian/copyright.
+  * Remove obsolete fields Contact, Name from debian/upstream/metadata (already
+    present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 30 Oct 2022 11:29:40 -0000
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -2,6 +2,7 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: evilwm
 Source: http://www.6809.org.uk/evilwm/
 Copyright: 1999-2015 Ciaran Anscomb <evilwm@6809.org.uk>
+Upstream-Contact: https://www.6809.org.uk/ciaran/
 
 Files: *
 Copyright: 1999-2015 Ciaran Anscomb <evilwm@6809.org.uk>

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,1 +1,1 @@
-debian-watch-does-not-check-gpg-signature
+debian-watch-does-not-check-openpgp-signature

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,5 +1,3 @@
-Name: evilwm
 Repository: https://www.6809.org.uk/git/evilwm.git
 Documentation: https://www.6809.org.uk/evilwm/manual.shtml
-Contact: https://www.6809.org.uk/ciaran/
 Bug-Submit: https://www.6809.org.uk/ciaran/


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Update renamed lintian tag names in lintian overrides. ([renamed-tag](https://lintian.debian.org/tags/renamed-tag))

* Set field Upstream-Contact in debian/copyright.

* Remove obsolete fields Contact, Name from debian/upstream/metadata (already present in machine-readable debian/copyright).


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/evilwm/7fc823e2-f590-4151-973f-d21efa64001c.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/7fc823e2-f590-4151-973f-d21efa64001c/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7fc823e2-f590-4151-973f-d21efa64001c/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7fc823e2-f590-4151-973f-d21efa64001c/diffoscope)).
